### PR TITLE
Fix COMM.BIN loading

### DIFF
--- a/src/noctis.cpp
+++ b/src/noctis.cpp
@@ -555,10 +555,11 @@ void run_goesnet_module() {
         exit(0xFF);
     } else {
         // It reacts to the presence of data in the communication file.
-        ch = fopen(comm, "wb");
+        ch = fopen(comm, "rb");
 
         if (ch != nullptr) {
-            uint32_t len = fseek(ch, 0, SEEK_END);
+            fseek(ch, 0, SEEK_END);
+            uint32_t len = ftell(ch);
             fseek(ch, 0, SEEK_SET);
             if (len == 2) {
                 if (ap_reached) {


### PR DESCRIPTION
Previously, the code would incorrectly assume the size of the file is 0 bytes and therefore not do anything, as [fseek](https://en.cppreference.com/w/c/io/fseek) returns 0 on success. With this change in place, the file is loaded correctly and any actions specified within the COMM.BIN file will be taken.